### PR TITLE
Add AutoPlaylist plugin source

### DIFF
--- a/sources.txt
+++ b/sources.txt
@@ -166,6 +166,7 @@ https://raw.githubusercontent.com/vosmiic/jellyfin-ani-sync/master/manifest.json
 https://raw.githubusercontent.com/waynedillon220/Jellyfin-Chat/main/manifest.json | https://github.com/waynedillon220/Jellyfin-Chat | *.*
 https://raw.githubusercontent.com/webbster64/jellyfin-plugin-AnimeMultiSource/main/manifest.json | https://github.com/webbster64/jellyfin-plugin-AnimeMultiSource/ | *.*
 https://raw.githubusercontent.com/xiaolee-lab/jellyfin-plugin-strmposter/refs/heads/main/manifest.json | https://github.com/xiaolee-lab/jellyfin-plugin-strmposter | *.*
+https://raw.githubusercontent.com/yonie/jellyfin-plugin-autoplaylist/main/manifest.json | https://github.com/yonie/jellyfin-plugin-autoplaylist | 10.11
 https://raw.githubusercontent.com/ZL154/AchievementBadges_for_Jellyfin/main/manifest.json | https://github.com/ZL154/AchievementBadges_for_Jellyfin | *.*
 https://raw.githubusercontent.com/ZL154/jellyfin-plugin-startrack/main/manifest.json | https://github.com/ZL154/jellyfin-plugin-startrack | *.*
 https://raw.githubusercontent.com/ZL154/jellyfin-projectionist/main/manifest.json | https://github.com/ZL154/jellyfin-projectionist | *.*


### PR DESCRIPTION
### Adding sources:

Plugin Source: https://raw.githubusercontent.com/yonie/jellyfin-plugin-autoplaylist/main/manifest.json

Plugin Repo URL: https://github.com/yonie/jellyfin-plugin-autoplaylist

1. [x] Have you sorted the sources.txt file alphabetically?

2. [x] Have you deleted duplicate lines in sources.txt?

3. [x] Have you checked if the plugin already exists in the Jellyfin Catalogue?

---

Adds **AutoPlaylist**, which curates thematic music playlists from an existing music library using a local LLM served by Ollama. Playlists it creates are tagged, so playlists the user made by hand are never modified, and curation runs as a nightly scheduled task. Only `targetAbi` 10.11.0.0 is published, so the constraint is `10.11` rather than `*.*`.

Validated with `node update.js 10.11`: the source is fetched and processed, and AutoPlaylist 1.0.3.0 lands in the generated `plugins/manifest.10.11.json` (235 plugins total). The only fetch failure in that run was the pre-existing `https://intro-skipper.org/manifest.json` (`Unexpected end of JSON input`), unrelated to this change.

The inserted line sits between `xiaolee-lab/...` and `ZL154/...`. There is one pre-existing out-of-order line in the file (`PunchPlay`, sitting inside the `github.com/cxfksword` block); I left it alone to keep this diff to a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
